### PR TITLE
Switch deployment to Cloudflare Workers (static assets)

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,0 +1,7 @@
+.git/
+.gitignore
+.assetsignore
+wrangler.jsonc
+README.md
+LICENSE
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 contractorpermie
 ================
 
-Source for one page app contractorpermie.com
+Source for one page app contractorpermie.com.
 
-Requires [`s3cmd`](https://s3tools.org/s3cmd) and [`aws`](https://aws.amazon.com/cli/) CLI to sync to S3 and invalidate the Cloudfont cache
+Deployed via [Cloudflare Pages](https://pages.cloudflare.com/). Pushes to `master` deploy to production; pull requests and other branches get automatic preview URLs.
 
 Contributors:
 * [Simon Rumble](http://www.simonrumble.com/)

--- a/sync_to_s3.sh
+++ b/sync_to_s3.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-s3cmd sync --acl-public --preserve --recursive --exclude-from=.gitignore ./ s3://www.contractorpermie.com/
-
-# Turns out I'm using Fastly not Cloudfront so don't need this
-# aws cloudfront create-invalidation --distribution-id E1ZW5KU8M6GM50 \
-# --invalidation-batch "{ \"Paths\": { \"Quantity\": 1, \"Items\": [ \"/*\" ] }, \"CallerReference\": \"`date +%s`\" }"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "contractorpermie",
+  "compatibility_date": "2026-05-11",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
Switches deployment from S3 + Fastly to a Cloudflare Worker serving static assets, with automatic preview deployments for branches and PRs.

## Changes
- Remove `sync_to_s3.sh` (no longer needed; deploys are git-driven via Cloudflare Workers Builds).
- Add `wrangler.jsonc` declaring the repo root as the static-assets directory.
- Add `.assetsignore` so `README.md`, `LICENSE`, `wrangler.jsonc` and dotfiles aren't served as site assets.
- Update `README.md` to reflect the new deployment model.

## Verification
- Production site `contractorpermie.com` and `www.contractorpermie.com` are now served from the Cloudflare Worker via routes, with Cloudflare-issued TLS.
- This PR itself should produce a preview deployment URL (the whole point of switching).

## Follow-up (not in this PR)
- Decommission Fastly service and remove the `_acme-challenge` Fastly validation CNAME.
- Empty and delete S3 bucket `www.contractorpermie.com`.
- Optionally delete the Route 53 hosted zone after DNS is proven stable on Cloudflare.