### PR TITLE
Fix Statsig SDK: add session replay and web analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,13 +36,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-NKH9CR8');</script>
 <!-- End Google Tag Manager -->
 <!-- Statsig SDK -->
-<script src="https://unpkg.com/@statsig/js-client"></script>
+<script src="https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+session-replay+web-analytics.min.js"></script>
 <script>
 (function() {
-	var statsigClient = new window.__STATSIG__.StatsigClient(
-		'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5',
-		{}
-	);
+	var _s = window.Statsig;
+	var statsigClient = new _s.StatsigClient('**************************************************', {});
+	_s.runStatsigSessionReplay(statsigClient);
+	_s.runStatsigAutoCapture(statsigClient);
 	statsigClient.initializeAsync();
 	window.statsigClient = statsigClient;
 })();
@@ -211,24 +211,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				})
 
 				if (window.statsigClient) {
-					window.statsigClient.logEvent({
-						eventName: 'change',
-						metadata: {
-							'fieldChanged': String(this.id),
-							'fieldValue': String(fieldValue),
-							'annualex_unformatted': String(unformat($('#annualex').val())),
-							'annualinc_unformatted': String(unformat($('#annualinc').val())),
-							'dailyinc_unformatted': String(unformat($('#dailyinc').val())),
-							'annualex_formatted': String($('#annualex').val()),
-							'annualinc_formatted': String($('#annualinc').val()),
-							'dailyinc_formatted': String($('#dailyinc').val()),
-							'daysperweek': String($('#daysperweek').val() * 1),
-							'weekdays': String($('#weekdays').val() * 1),
-							'pubhols': String($('#pubhols').val() * 1),
-							'sickleave': String($('#sickleave').val() * 1),
-							'superannuation': String($('#superannuation').val() * 1),
-							'daysworked': String($('#daysworked').val() * 1)
-						}
+					window.statsigClient.logEvent('change', this.id, {
+						'fieldValue': String(fieldValue),
+						'annualex_unformatted': String(unformat($('#annualex').val())),
+						'annualinc_unformatted': String(unformat($('#annualinc').val())),
+						'dailyinc_unformatted': String(unformat($('#dailyinc').val())),
+						'annualex_formatted': String($('#annualex').val()),
+						'annualinc_formatted': String($('#annualinc').val()),
+						'dailyinc_formatted': String($('#dailyinc').val()),
+						'daysperweek': String($('#daysperweek').val() * 1),
+						'weekdays': String($('#weekdays').val() * 1),
+						'pubhols': String($('#pubhols').val() * 1),
+						'sickleave': String($('#sickleave').val() * 1),
+						'superannuation': String($('#superannuation').val() * 1),
+						'daysworked': String($('#daysworked').val() * 1)
 					});
 				}
 


### PR DESCRIPTION
The previous Statsig integration (PR #11) used the bare `@statsig/js-client` bundle from unpkg which doesn't include session replay or web analytics, and used the legacy API.

## Changes
- Switch CDN to the full `js-client+session-replay+web-analytics` bundle from jsDelivr
- Use `window.Statsig` namespace (new SDK API) instead of `window.__STATSIG__`
- Add `runStatsigSessionReplay` and `runStatsigAutoCapture` calls on init
- Fix `logEvent` to use correct signature: `logEvent(name, value, metadata)` instead of the legacy object form