### PR TITLE
Fix Statsig client key

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script>
 (function() {
 	var _s = window.Statsig;
-	var statsigClient = new _s.StatsigClient('**************************************************', {});
+	var statsigClient = new _s.StatsigClient('client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5', {});
 	_s.runStatsigSessionReplay(statsigClient);
 	_s.runStatsigAutoCapture(statsigClient);
 	statsigClient.initializeAsync();


### PR DESCRIPTION
The client key was written as literal asterisks in the previous PR due to a tool redaction issue. This replaces them with the real key.