### PR TITLE
Update 2026 defaults: 9 NSW public holidays, 12% super

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			<div class="hero-unit">
 				
 				<p>This calculator helps you compare "package" or "gross" salaries, daily contract rates and their equivalent standard salary number.</p>
-				<p>Updated for 2024 public holidays (including bank holiday) and the increase of super to 11.0% for financial years 2023-2024. <a href="https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/super-guarantee">Super percentage is increasing until FY2028</a></p>
+				<p>Updated for 2026 NSW public holidays (9 weekday holidays) and super at 12.0% for FY2025-2026. <a href="https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/super-guarantee">The super guarantee has reached its final rate of 12%</a></p>
 
 
 			</div>
@@ -99,15 +99,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 							<label>Weekdays in year</label>
 							<input type="text" value="261" id="weekdays" rel="tooltip" title="52 times days worked per week, so not 100% accurate">
 							<label>Public holidays</label>
-							<input type="text" value="10" id="pubhols" rel="tooltip" title="Based on NSW weekday public holidays for 2014">
+							<input type="text" value="9" id="pubhols" rel="tooltip" title="Based on NSW weekday public holidays for 2026">
 							<label>Annual leave</label>
 							<input type="text" value="20" id="annualleave" rel="tooltip" title="Four weeks' holidays if you work five days a week">
 							<label>Sick leave</label>
 							<input type="text" value="5" id="sickleave" rel="tooltip" title="Don't get sick more than a week">
 							<label>Super percentage</label>
-							<input type="text" value="11.0" id="superannuation">
+							<input type="text" value="12.0" id="superannuation">
 							<label><b>Net days worked</b></label>
-							<input type="text" value="225" id="daysworked">
+							<input type="text" value="227" id="daysworked">
 						</fieldset>
 					</div>
 


### PR DESCRIPTION
- Public holidays: 10 → 9 (NSW 2026 per Fair Work Ombudsman; includes Anzac Day substitute Mon 27 Apr, no bank holiday)
- Super guarantee: 11.0% → 12.0% (final rate from FY2025-26, no longer increasing)
- Net days worked: 225 → 227
- Update hero text and tooltip to reference 2026