### PR TITLE
Risk premium settings panel behind Statsig gate

### DIFF
--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -244,6 +244,80 @@ html.design-2026 .row:last-child p:last-child {
     margin: 0;
 }
 
+/* ---- Settings toggle (risk_premium gate) ---- */
+html.design-2026 .settings-toggle {
+    display: -webkit-flex;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 12px;
+    padding: 9px 14px;
+    background: #f7fafc;
+    border: 1.5px solid #cbd5e0 !important;
+    border-radius: 8px !important;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #4a5568;
+    cursor: pointer;
+    text-align: left;
+    -webkit-transition: border-color .15s, background .15s;
+    transition: border-color .15s, background .15s;
+    -webkit-box-shadow: none !important;
+    box-shadow: none !important;
+}
+
+html.design-2026 .settings-toggle:hover {
+    border-color: #38a169 !important;
+    background: #f0fff4;
+    color: #276749;
+}
+
+html.design-2026 .settings-chevron {
+    margin-left: auto;
+    font-size: 10px;
+    color: #a0aec0;
+}
+
+/* ---- Risk premium section ---- */
+html.design-2026 #risk-premium-section {
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #edf2f7;
+}
+
+html.design-2026 #risk-premium-section label {
+    margin-top: 0;
+    color: #2d3748;
+    font-size: 0.875rem;
+}
+
+html.design-2026 #riskpremium-display {
+    color: #38a169;
+}
+
+html.design-2026 #riskpremium {
+    width: 100%;
+    margin: 8px 0 4px;
+    accent-color: #38a169;
+    cursor: pointer;
+}
+
+html.design-2026 .risk-premium-labels {
+    display: -webkit-flex;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.6875rem;
+    color: #a0aec0;
+    margin-bottom: 8px;
+}
+
+html.design-2026 .risk-premium-hint {
+    font-size: 0.8rem;
+    color: #718096;
+    margin: 0;
+    line-height: 1.55;
+}
+
 /* ---- Responsive ---- */
 @media (max-width: 620px) {
     html.design-2026 .row > form {

--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -218,6 +218,19 @@ html.design-2026 input#dailyinc {
     border-color: #9ae6b4 !important;
 }
 
+/* Premium day rate — stronger green, read-only output */
+html.design-2026 input#dailypremium {
+    font-weight: 700;
+    background: #c6f6d5;
+    border-color: #68d391 !important;
+    color: #276749;
+}
+
+html.design-2026 #risk-pct-label {
+    color: #38a169;
+    font-weight: 700;
+}
+
 
 
 /* ---- Description row ---- */

--- a/index.html
+++ b/index.html
@@ -106,6 +106,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 							<input type="text" placeholder="76650" id="annualinc" rel="tooltip" title="What the recruiter will quote you as 'package', inc super ex tax" />
 							<label>Daily contract rate (inc superannuation, ex GST)</label>
 							<input type="text" placeholder="337.67" id="dailyinc" rel="toolip" title="Daily rate net of the standard days off in 'Assumptions'" />
+							<div id="daily-premium-row" style="display:none">
+								<label>Daily rate with <span id="risk-pct-label">0%</span> risk premium</label>
+								<input type="text" id="dailypremium" readonly placeholder="—" title="Day rate including the risk premium — what you should actually charge" />
+							</div>
 						</fieldset>
 					</div>
 					<div class="span5">
@@ -163,7 +167,36 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			}
 
 
-			$('input').change(function() {
+			var CP_PREF_KEYS = ['daysperweek', 'pubhols', 'annualleave', 'sickleave', 'superannuation', 'riskpremium'];
+
+		function savePrefs() {
+			CP_PREF_KEYS.forEach(function(k) {
+				var el = document.getElementById(k);
+				if (el) localStorage.setItem('cp.pref.' + k, el.value);
+			});
+		}
+
+		function loadPrefs() {
+			var restored = false;
+			CP_PREF_KEYS.forEach(function(k) {
+				var val = localStorage.getItem('cp.pref.' + k);
+				if (val !== null) {
+					var el = document.getElementById(k);
+					if (el) { el.value = val; restored = true; }
+				}
+			});
+			if (restored) {
+				$('#weekdays').val($('#daysperweek').val() * 52);
+				$('#daysworked').val(
+					parseInt($('#weekdays').val()) - parseInt($('#pubhols').val()) -
+					parseInt($('#annualleave').val()) - parseInt($('#sickleave').val())
+				);
+				var riskPct = parseFloat($('#riskpremium').val() || 0);
+				if (riskPct > 0) $('#riskpremium-display').text(riskPct + '%');
+			}
+		}
+
+		$('input').change(function() {
 				// Record the actually-entered field value before we format it down lower
 				fieldValue = this.value;
 
@@ -178,27 +211,24 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				switch(this.id) {
 					case 'annualex':
 						$('#annualinc').val($('#annualex').val() * superannuation);
-						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
+						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val());
 						break;
 
 					case 'annualinc':
 						$('#annualex').val($('#annualinc').val() * (1 / superannuation));
-						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
+						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val());
 						break;
 
 					case 'dailyinc':
-						$('#annualinc').val($('#dailyinc').val() / riskMultiplier * $('#daysworked').val());
+						$('#annualinc').val($('#dailyinc').val() * $('#daysworked').val());
 						$('#annualex').val($('#annualinc').val() * (1/superannuation));
 						break;
 
 					default:
 					if (this.id === 'riskpremium') {
-						// Premium changed: keep salary fixed, update day rate
+						// Premium changed: update display label; dailyinc stays unrisked,
+						// dailypremium is updated in the block below after formatting.
 						$('#riskpremium-display').text(this.value + '%');
-						if ($('#annualex').val() !== '') {
-							riskMultiplier = 1.0 + parseFloat(this.value) / 100;
-							$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
-						}
 					} else {
 						// One of the other assumptions changed
 						$('#weekdays').val($('#daysperweek').val() * 52);
@@ -214,10 +244,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						$('#daysworked').val(
 							$('#weekdays').val() - $('#pubhols').val() - $('#annualleave').val() - $('#sickleave').val()
 						);
-						// If they've already done a calculation in the top bit, recalculate.
 						// Keep the day rate fixed; salary adjusts to match.
 						if ($('#annualex').val() !== '') {
-							$('#annualinc').val($('#dailyinc').val() / riskMultiplier * $('#daysworked').val());
+							$('#annualinc').val($('#dailyinc').val() * $('#daysworked').val());
 							$('#annualex').val($('#annualinc').val() * (1 / superannuation));
 						}
 					}
@@ -227,6 +256,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						this.value = format((this.value * 1).toFixed(0));
 					});
 				}
+				// Update premium day rate field (only when risk_premium gate is active)
+				if (window.__riskPremiumEnabled) {
+					var rawDaily = unformat($('#dailyinc').val());
+					var riskPct = parseFloat($('#riskpremium').val() || 0);
+					if (rawDaily > 0 && riskPct > 0) {
+						$('#dailypremium').val(format((rawDaily * riskMultiplier).toFixed(0)));
+						$('#risk-pct-label').text(riskPct + '%');
+						$('#daily-premium-row').show();
+					} else {
+						$('#dailypremium').val('');
+						$('#daily-premium-row').hide();
+					}
+				}
+				savePrefs();
 				dataLayer.push({
 					'event': 'change',
 					'fieldChanged': this.id,
@@ -268,6 +311,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				}
 
 			});
+		loadPrefs();
+
 		// Add the tooltips to the input fields
 		$('input').tooltip({'placement' : 'right'})
 
@@ -283,6 +328,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 					document.documentElement.classList.add('design-2026');
 				}
 				if (window.statsigClient && window.statsigClient.checkGate('risk_premium')) {
+					window.__riskPremiumEnabled = true;
 					var toggle = document.getElementById('settings-toggle');
 					var wrap = document.getElementById('settings-fieldset-wrap');
 					var riskSection = document.getElementById('risk-premium-section');

--- a/index.html
+++ b/index.html
@@ -109,23 +109,32 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						</fieldset>
 					</div>
 					<div class="span5">
-						<fieldset>
-							<legend>Assumptions</legend>
-							<label>Days worked per week</label>
-							<input type="text" value="5" id="daysperweek" rel="tooltip" title="Change for part-timers">
-							<label>Weekdays in year</label>
-							<input type="text" value="261" id="weekdays" rel="tooltip" title="52 times days worked per week, so not 100% accurate">
-							<label>Public holidays</label>
-							<input type="text" value="9" id="pubhols" rel="tooltip" title="Based on NSW weekday public holidays for 2026">
-							<label>Annual leave</label>
-							<input type="text" value="20" id="annualleave" rel="tooltip" title="Four weeks' holidays if you work five days a week">
-							<label>Sick leave</label>
-							<input type="text" value="5" id="sickleave" rel="tooltip" title="Don't get sick more than a week">
-							<label>Super percentage</label>
-							<input type="text" value="12.0" id="superannuation">
-							<label><b>Net days worked</b></label>
-							<input type="text" value="227" id="daysworked">
-						</fieldset>
+						<button type="button" id="settings-toggle" class="btn settings-toggle" style="display:none" aria-expanded="false">Settings <span class="settings-chevron">&#9660;</span></button>
+						<div id="settings-fieldset-wrap">
+							<fieldset>
+								<legend>Assumptions</legend>
+								<div id="risk-premium-section" style="display:none">
+									<label>Risk premium: <strong id="riskpremium-display">0%</strong></label>
+									<input type="range" id="riskpremium" min="0" max="30" step="5" value="0" title="Extra % a contractor charges above the direct mathematical equivalent">
+									<div class="risk-premium-labels"><span>0%</span><span>15%</span><span>30%</span></div>
+									<p class="risk-premium-hint">The premium a contractor should charge above the direct equivalent, to compensate for no leave entitlements or job security.</p>
+								</div>
+								<label>Days worked per week</label>
+								<input type="text" value="5" id="daysperweek" rel="tooltip" title="Change for part-timers">
+								<label>Weekdays in year</label>
+								<input type="text" value="261" id="weekdays" rel="tooltip" title="52 times days worked per week, so not 100% accurate">
+								<label>Public holidays</label>
+								<input type="text" value="9" id="pubhols" rel="tooltip" title="Based on NSW weekday public holidays for 2026">
+								<label>Annual leave</label>
+								<input type="text" value="20" id="annualleave" rel="tooltip" title="Four weeks' holidays if you work five days a week">
+								<label>Sick leave</label>
+								<input type="text" value="5" id="sickleave" rel="tooltip" title="Don't get sick more than a week">
+								<label>Super percentage</label>
+								<input type="text" value="12.0" id="superannuation">
+								<label><b>Net days worked</b></label>
+								<input type="text" value="227" id="daysworked">
+							</fieldset>
+						</div>
 					</div>
 
 				</form>
@@ -158,7 +167,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				// Record the actually-entered field value before we format it down lower
 				fieldValue = this.value;
 
-				superannuation = 1.0 + $('#superannuation').val() / 100;
+				superannuation = 1.0 + parseFloat($('#superannuation').val()) / 100;
+				var riskMultiplier = 1.0 + parseFloat($('#riskpremium').val() || 0) / 100;
 
 				// Unformat before we do calculations
 				$('#annualex,#annualinc,#dailyinc').each(function() {
@@ -168,38 +178,48 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 				switch(this.id) {
 					case 'annualex':
 						$('#annualinc').val($('#annualex').val() * superannuation);
-						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val());
+						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
 						break;
 
 					case 'annualinc':
 						$('#annualex').val($('#annualinc').val() * (1 / superannuation));
-						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val());
+						$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
 						break;
 
 					case 'dailyinc':
-						$('#annualinc').val($('#dailyinc').val() * $('#daysworked').val());
+						$('#annualinc').val($('#dailyinc').val() / riskMultiplier * $('#daysworked').val());
 						$('#annualex').val($('#annualinc').val() * (1/superannuation));
 						break;
 
 					default:
-					// One of the assumptions changed
-					$('#weekdays').val($('#daysperweek').val() * 52);
-
-					// Calculate annual leave pro rata from 20, but no more than 20
-					if ($('#daysperweek').val() > 5) {
-						alert("You're really gonna work more than 5 days every week? That sucks!");
-						$('#annualleave').val(20);
+					if (this.id === 'riskpremium') {
+						// Premium changed: keep salary fixed, update day rate
+						$('#riskpremium-display').text(this.value + '%');
+						if ($('#annualex').val() !== '') {
+							riskMultiplier = 1.0 + parseFloat(this.value) / 100;
+							$('#dailyinc').val($('#annualinc').val() / $('#daysworked').val() * riskMultiplier);
+						}
 					} else {
-						$('#annualleave').val(Math.round(($('#daysperweek').val()/5)*20));
-					}
+						// One of the other assumptions changed
+						$('#weekdays').val($('#daysperweek').val() * 52);
 
-					$('#daysworked').val(
-						$('#weekdays').val() - $('#pubhols').val() - $('#annualleave').val() - $('#sickleave').val()
-						// If they've already done a calculation in the top bit, recalculate
-					);
-					if ($('#annualex').val() !== '') {
-						$('#annualinc').val($('#dailyinc').val() * $('#daysworked').val());
-						$('#annualex').val($('#annualinc').val() * (1 / superannuation));
+						// Calculate annual leave pro rata from 20, but no more than 20
+						if ($('#daysperweek').val() > 5) {
+							alert("You're really gonna work more than 5 days every week? That sucks!");
+							$('#annualleave').val(20);
+						} else {
+							$('#annualleave').val(Math.round(($('#daysperweek').val()/5)*20));
+						}
+
+						$('#daysworked').val(
+							$('#weekdays').val() - $('#pubhols').val() - $('#annualleave').val() - $('#sickleave').val()
+						);
+						// If they've already done a calculation in the top bit, recalculate.
+						// Keep the day rate fixed; salary adjusts to match.
+						if ($('#annualex').val() !== '') {
+							$('#annualinc').val($('#dailyinc').val() / riskMultiplier * $('#daysworked').val());
+							$('#annualex').val($('#annualinc').val() * (1 / superannuation));
+						}
 					}
 				}
 				if ($('#annualex').val() !== '') {
@@ -223,7 +243,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 					'pubhols': ($('#pubhols').val() * 1),
 					'sickleave': ($('#sickleave').val() * 1),
 					'superannuation': ($('#superannuation').val() * 1),
-					'daysworked': ($('#daysworked').val() * 1)
+					'daysworked': ($('#daysworked').val() * 1),
+					'riskpremium': parseFloat($('#riskpremium').val() || 0)
 
 				})
 
@@ -241,7 +262,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						'pubhols': String($('#pubhols').val() * 1),
 						'sickleave': String($('#sickleave').val() * 1),
 						'superannuation': String($('#superannuation').val() * 1),
-						'daysworked': String($('#daysworked').val() * 1)
+						'daysworked': String($('#daysworked').val() * 1),
+						'riskpremium': String(parseFloat($('#riskpremium').val() || 0))
 					});
 				}
 
@@ -249,11 +271,30 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		// Add the tooltips to the input fields
 		$('input').tooltip({'placement' : 'right'})
 
-		// Apply new design when update_styles_2026 gate is on
+		// Live display update for risk premium slider (fires while dragging)
+		$('#riskpremium').on('input', function() {
+			$('#riskpremium-display').text(this.value + '%');
+		});
+
+		// Apply new design and feature gates after Statsig initialises
 		if (window.__statsigReady) {
 			window.__statsigReady.then(function() {
 				if (window.statsigClient && window.statsigClient.checkGate('update_styles_2026')) {
 					document.documentElement.classList.add('design-2026');
+				}
+				if (window.statsigClient && window.statsigClient.checkGate('risk_premium')) {
+					var toggle = document.getElementById('settings-toggle');
+					var wrap = document.getElementById('settings-fieldset-wrap');
+					var riskSection = document.getElementById('risk-premium-section');
+					toggle.style.display = 'block';
+					riskSection.style.display = 'block';
+					wrap.style.display = 'none';
+					toggle.addEventListener('click', function() {
+						var open = wrap.style.display !== 'none';
+						wrap.style.display = open ? 'none' : 'block';
+						this.setAttribute('aria-expanded', String(!open));
+						this.querySelector('.settings-chevron').textContent = open ? '\u25bc' : '\u25b2';
+					});
 				}
 			});
 		}


### PR DESCRIPTION
Adds a collapsible settings panel gated behind the `risk_premium` Statsig feature gate.

**What's in the gate:**
- A "Settings ▾" toggle button replaces the always-visible assumptions column
- Panel opens/closes on click, collapsed by default
- Risk premium range slider (0–30%, step 5%) at the top of the panel — defaults to 0% (direct mathematical equivalent)

**Calculation changes:**
- `annualex`/`annualinc` → `dailyinc` now multiplied by `(1 + risk%/100)`
- `dailyinc` → salary now divided by the risk multiplier before converting
- When other assumptions change (days, holidays etc), day rate stays fixed; salary adjusts, respecting the risk multiplier
- When risk premium slider moves, salary stays fixed; day rate updates

**Without the gate:** site behaves identically to before (risk multiplier = 1.0, no toggle shown).

`riskpremium` added to both dataLayer and Statsig `logEvent`.