### PR TITLE
design-2026: Contract or Permie? as primary heading

### DIFF
--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -52,14 +52,25 @@ html.design-2026 .container {
     width: auto !important;
 }
 
-html.design-2026 h1 {
-    font-size: 2.25rem;
-    font-weight: 700;
+html.design-2026 .site-name {
+    display: block !important;
+    font-size: 2.75rem;
+    font-weight: 800;
     color: #1a202c;
+    margin: 0 0 4px;
+    text-shadow: none;
+    letter-spacing: -0.035em;
+    line-height: 1.1;
+}
+
+html.design-2026 h1 {
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: #4a5568;
     margin: 0 0 20px;
     text-shadow: none;
-    letter-spacing: -0.025em;
-    line-height: 1.2;
+    letter-spacing: 0;
+    line-height: 1.4;
 }
 
 /* ---- Hero / intro card ---- */
@@ -355,7 +366,11 @@ html.design-2026 .risk-premium-hint {
         padding: 0 16px;
     }
 
+    html.design-2026 .site-name {
+        font-size: 2rem;
+    }
+
     html.design-2026 h1 {
-        font-size: 1.4rem;
+        font-size: 1rem;
     }
 }

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		</div>
 
 		<div class="container">
+			<div class="site-name hide">Contract or Permie?</div>
 			<h1>Compare contract rates with permanent</h1>
 			<div class="hero-unit">
 				


### PR DESCRIPTION
When the `update_styles_2026` gate is on:

- Adds `.site-name` div with "Contract or Permie?" above the h1, styled as the primary hero heading (2.75rem, weight 800)
- Demotes the h1 "Compare contract rates with permanent" to a subheading (1.1rem, weight 400, muted colour)
- The `.site-name` div uses Bootstrap's `.hide` class so it's invisible in the legacy Bootstrap layout; `html.design-2026 .site-name` overrides it to `display: block`
- Responsive: .site-name 2rem, h1 1rem at ≤620px