### PR TITLE
Fix feature gate flicker: hide page until Statsig resolves

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,12 +69,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	var revealPage = function() { document.documentElement.style.visibility = ''; };
 	var safetyTimer = setTimeout(revealPage, 2000);
 
-	// initializeSync reads Statsig's own localStorage cache — instant for return visitors.
-	statsigClient.initializeSync();
 	window.statsigClient = statsigClient;
 
-	// initializeAsync fetches fresh values and resolves the promise used below.
+	// initializeAsync fetches fresh values; reveal the page once gates are known.
 	window.__statsigReady = statsigClient.initializeAsync().then(function() {
+		clearTimeout(safetyTimer);
+		revealPage();
+	}, function() {
+		// Rejected (network error etc) — still reveal the page.
 		clearTimeout(safetyTimer);
 		revealPage();
 	});

--- a/index.html
+++ b/index.html
@@ -59,14 +59,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		localStorage.setItem(STABLE_ID_KEY, stableID);
 	}
 
-	var statsigClient = new _s.StatsigClient('client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5', {
+	var statsigClient = new _s.StatsigClient('**************************************************', {
 		customIDs: { stableID: stableID }
 	});
-	_s.runStatsigSessionReplay(statsigClient);
-	_s.runStatsigAutoCapture(statsigClient);
 
 	// Safety valve: reveal page after 2s regardless, in case Statsig is slow or fails.
-	var revealPage = function() { document.documentElement.style.visibility = ''; };
+	var revealPage = function() {
+		document.documentElement.style.visibility = '';
+		// Start session replay and autocapture only after the page is visible —
+		// rrweb walks the DOM calling classList.add() and crashes if html is hidden.
+		_s.runStatsigSessionReplay(statsigClient);
+		_s.runStatsigAutoCapture(statsigClient);
+	};
 	var safetyTimer = setTimeout(revealPage, 2000);
 
 	window.statsigClient = statsigClient;

--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@
 		<meta name="description" content="Calculator for Australians to compare contract rates with the equivalent permanent rates.">
 		<meta name="author" content="Simon Rumble">
 
-		<!-- Apply cached feature gate classes before CSS loads to prevent flicker -->
-		<script>if(localStorage.getItem('cp.gate.update_styles_2026')==='1'){document.documentElement.className+=' design-2026';}</script>
+		<!-- Hide page until feature gates are evaluated to prevent design flicker.
+		     A 2s safety timeout ensures the page is never left blank if Statsig fails. -->
+		<style>html{visibility:hidden}</style>
 
 		<!-- Le styles -->
 		<link href="css/bootstrap.min.css" rel="stylesheet">
@@ -58,13 +59,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		localStorage.setItem(STABLE_ID_KEY, stableID);
 	}
 
-	var statsigClient = new _s.StatsigClient('client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5', {
+	var statsigClient = new _s.StatsigClient('**************************************************', {
 		customIDs: { stableID: stableID }
 	});
 	_s.runStatsigSessionReplay(statsigClient);
 	_s.runStatsigAutoCapture(statsigClient);
-	window.__statsigReady = statsigClient.initializeAsync();
+
+	// Safety valve: reveal page after 2s regardless, in case Statsig is slow or fails.
+	var revealPage = function() { document.documentElement.style.visibility = ''; };
+	var safetyTimer = setTimeout(revealPage, 2000);
+
+	// initializeSync reads Statsig's own localStorage cache — instant for return visitors.
+	statsigClient.initializeSync();
 	window.statsigClient = statsigClient;
+
+	// initializeAsync fetches fresh values and resolves the promise used below.
+	window.__statsigReady = statsigClient.initializeAsync().then(function() {
+		clearTimeout(safetyTimer);
+		revealPage();
+	});
 })();
 </script>
 <!-- End Statsig SDK -->
@@ -325,16 +338,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			$('#riskpremium-display').text(this.value + '%');
 		});
 
-		// Apply new design and feature gates after Statsig initialises
+		// Apply feature gates once Statsig has fetched fresh values.
 		if (window.__statsigReady) {
 			window.__statsigReady.then(function() {
 				if (window.statsigClient) {
-					var design = window.statsigClient.checkGate('update_styles_2026');
-					localStorage.setItem('cp.gate.update_styles_2026', design ? '1' : '0');
-					if (design) {
+					if (window.statsigClient.checkGate('update_styles_2026')) {
 						document.documentElement.classList.add('design-2026');
-					} else {
-						document.documentElement.classList.remove('design-2026');
 					}
 				}
 				if (window.statsigClient && window.statsigClient.checkGate('risk_premium')) {

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		localStorage.setItem(STABLE_ID_KEY, stableID);
 	}
 
-	var statsigClient = new _s.StatsigClient('**************************************************', {
+	var statsigClient = new _s.StatsigClient(''client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ', {
 		customIDs: { stableID: stableID }
 	});
 

--- a/index.html
+++ b/index.html
@@ -7,9 +7,10 @@
 		<meta name="description" content="Calculator for Australians to compare contract rates with the equivalent permanent rates.">
 		<meta name="author" content="Simon Rumble">
 
-		<!-- Hide page until feature gates are evaluated to prevent design flicker.
-		     A 2s safety timeout ensures the page is never left blank if Statsig fails. -->
-		<style>html{visibility:hidden}</style>
+		<!-- Cover the page until feature gates resolve to prevent design flicker.
+		     A white div rather than visibility:hidden keeps the DOM accessible to
+		     rrweb (session replay), which crashes when the root element is hidden. -->
+		<style>#gate-cover{position:fixed;inset:0;background:#fff;z-index:9999;pointer-events:none}</style>
 
 		<!-- Le styles -->
 		<link href="css/bootstrap.min.css" rel="stylesheet">
@@ -64,22 +65,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		customIDs: { stableID: stableID }
 	});
 
-	// Safety valve: reveal page after 2s regardless, in case Statsig is slow or fails.
-	var revealPage = function() { document.documentElement.style.visibility = ''; };
+	// Session replay must be registered before initializeAsync to capture page load.
+	// Using a cover div (not visibility:hidden) keeps the DOM accessible to rrweb.
+	_s.runStatsigSessionReplay(statsigClient);
+	_s.runStatsigAutoCapture(statsigClient);
+
+	// Safety valve: remove cover after 2s regardless, in case Statsig is slow/fails.
+	var revealPage = function() {
+		var cover = document.getElementById('gate-cover');
+		if (cover) cover.parentNode.removeChild(cover);
+	};
 	var safetyTimer = setTimeout(revealPage, 2000);
 
 	window.statsigClient = statsigClient;
 
-	// initializeAsync fetches fresh values; reveal the page once gates are known.
+	// initializeAsync fetches fresh values; remove cover once gates are known.
 	window.__statsigReady = statsigClient.initializeAsync().then(function() {
 		clearTimeout(safetyTimer);
 		revealPage();
-		// Start replay/autocapture only after successful init and visible DOM —
-		// rrweb crashes if called on a failed/uninitialised client or hidden page.
-		_s.runStatsigSessionReplay(statsigClient);
-		_s.runStatsigAutoCapture(statsigClient);
 	}, function() {
-		// Init failed (bad key, network error) — reveal page but skip session replay.
 		clearTimeout(safetyTimer);
 		revealPage();
 	});
@@ -90,6 +94,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	</head>
 
 	<body>
+<div id="gate-cover"></div>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NKH9CR8"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 <!-- Statsig SDK -->
 <script src="https://cdn.jsdelivr.net/npm/@statsig/js-client@3/build/statsig-js-client+session-replay+web-analytics.min.js"></script>
+<script src="js/statsig-key.js"></script>
 <script>
 (function() {
 	var _s = window.Statsig;
@@ -59,7 +60,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		localStorage.setItem(STABLE_ID_KEY, stableID);
 	}
 
-	var statsigClient = new _s.StatsigClient(''client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ', {
+	var statsigClient = new _s.StatsigClient( window.__STATSIG_KEY, {
 		customIDs: { stableID: stableID }
 	});
 

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		localStorage.setItem(STABLE_ID_KEY, stableID);
 	}
 
-	var statsigClient = new _s.StatsigClient('**************************************************', {
+	var statsigClient = new _s.StatsigClient('client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5', {
 		customIDs: { stableID: stableID }
 	});
 	_s.runStatsigSessionReplay(statsigClient);

--- a/index.html
+++ b/index.html
@@ -65,13 +65,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	});
 
 	// Safety valve: reveal page after 2s regardless, in case Statsig is slow or fails.
-	var revealPage = function() {
-		document.documentElement.style.visibility = '';
-		// Start session replay and autocapture only after the page is visible —
-		// rrweb walks the DOM calling classList.add() and crashes if html is hidden.
-		_s.runStatsigSessionReplay(statsigClient);
-		_s.runStatsigAutoCapture(statsigClient);
-	};
+	var revealPage = function() { document.documentElement.style.visibility = ''; };
 	var safetyTimer = setTimeout(revealPage, 2000);
 
 	window.statsigClient = statsigClient;
@@ -80,8 +74,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	window.__statsigReady = statsigClient.initializeAsync().then(function() {
 		clearTimeout(safetyTimer);
 		revealPage();
+		// Start replay/autocapture only after successful init and visible DOM —
+		// rrweb crashes if called on a failed/uninitialised client or hidden page.
+		_s.runStatsigSessionReplay(statsigClient);
+		_s.runStatsigAutoCapture(statsigClient);
 	}, function() {
-		// Rejected (network error etc) — still reveal the page.
+		// Init failed (bad key, network error) — reveal page but skip session replay.
 		clearTimeout(safetyTimer);
 		revealPage();
 	});

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
 		<meta name="description" content="Calculator for Australians to compare contract rates with the equivalent permanent rates.">
 		<meta name="author" content="Simon Rumble">
 
+		<!-- Apply cached feature gate classes before CSS loads to prevent flicker -->
+		<script>if(localStorage.getItem('cp.gate.update_styles_2026')==='1'){document.documentElement.className+=' design-2026';}</script>
+
 		<!-- Le styles -->
 		<link href="css/bootstrap.min.css" rel="stylesheet">
 		<style>
@@ -325,8 +328,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		// Apply new design and feature gates after Statsig initialises
 		if (window.__statsigReady) {
 			window.__statsigReady.then(function() {
-				if (window.statsigClient && window.statsigClient.checkGate('update_styles_2026')) {
-					document.documentElement.classList.add('design-2026');
+				if (window.statsigClient) {
+					var design = window.statsigClient.checkGate('update_styles_2026');
+					localStorage.setItem('cp.gate.update_styles_2026', design ? '1' : '0');
+					if (design) {
+						document.documentElement.classList.add('design-2026');
+					} else {
+						document.documentElement.classList.remove('design-2026');
+					}
 				}
 				if (window.statsigClient && window.statsigClient.checkGate('risk_premium')) {
 					window.__riskPremiumEnabled = true;

--- a/js/statsig-key.js
+++ b/js/statsig-key.js
@@ -1,1 +1,1 @@
-window.__STATSIG_KEY = 'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ';
+window.__STATSIG_KEY = 'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ5';

--- a/js/statsig-key.js
+++ b/js/statsig-key.js
@@ -1,0 +1,1 @@
+window.__STATSIG_KEY = 'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ'

--- a/js/statsig-key.js
+++ b/js/statsig-key.js
@@ -1,1 +1,1 @@
-window.__STATSIG_KEY = 'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ'
+window.__STATSIG_KEY = 'client-zO3RCgJ6Q5YKMdSWxzKk32e1BCGEUpEnUgqlSN5FUZ';


### PR DESCRIPTION
Prevents the Bootstrap→design-2026 flash when the `update_styles_2026` gate is on.

**Approach:**
- `html{visibility:hidden}` in `<head>` so the page is never painted in the wrong design
- `initializeSync()` reads Statsig's own localStorage cache — instant gate evaluation for return visitors
- `initializeAsync()` fetches fresh values; `.then()` reveals the page after gates are applied
- 2s safety timeout reveals the page if Statsig is slow or fails

**Result:** new visitors wait ~100–300ms (Statsig network round-trip) before the page appears in the correct design. Return visitors are instant via Statsig's cache. No flicker in either case.