### PR TITLE
Risk premium: show all three values side-by-side

### DIFF
--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -229,12 +229,50 @@ html.design-2026 input#dailyinc {
     border-color: #9ae6b4 !important;
 }
 
-/* Premium day rate — stronger green, read-only output */
-html.design-2026 input#dailypremium {
+/* Premium column — all three premium outputs */
+html.design-2026 input.premium-input {
     font-weight: 700;
     background: #c6f6d5;
     border-color: #68d391 !important;
     color: #276749;
+    display: none;
+}
+
+/* Side-by-side layout when premium column is visible */
+html.design-2026 .input-with-premium.showing-premium {
+    display: -webkit-flex;
+    display: flex;
+    gap: 12px;
+}
+
+html.design-2026 .input-with-premium.showing-premium input {
+    -webkit-flex: 1;
+    flex: 1;
+    width: auto !important;
+}
+
+/* Column heading */
+html.design-2026 #premium-col-head {
+    display: -webkit-flex;
+    display: flex;
+    gap: 12px;
+    margin-bottom: 6px;
+}
+
+html.design-2026 .premium-col-head-spacer {
+    -webkit-flex: 1;
+    flex: 1;
+}
+
+html.design-2026 .premium-col-head-label {
+    -webkit-flex: 1;
+    flex: 1;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #276749;
+    text-align: center;
 }
 
 html.design-2026 #risk-pct-label {

--- a/index.html
+++ b/index.html
@@ -125,17 +125,26 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			<div class="row">
 				<form>
 					<div class="span7">
-						<fieldset>
+						<fieldset id="main-fields">
 							<legend>Type in the number you have</legend>
+							<div id="premium-col-head" style="display:none">
+								<div class="premium-col-head-spacer"></div>
+								<div class="premium-col-head-label">With <span id="risk-pct-label">0%</span> risk premium</div>
+							</div>
 							<label><b>Standard annual salary</b></label>
-							<input type="text" placeholder="70000" id="annualex" rel="tooltip" title="What most people talk about as their annual salary, ex super and ex tax" />
+							<div class="input-with-premium">
+								<input type="text" placeholder="70000" id="annualex" rel="tooltip" title="What most people talk about as their annual salary, ex super and ex tax" />
+								<input type="text" id="annualex_premium" readonly class="premium-input" placeholder="—" title="Standard salary equivalent of the premium day rate" />
+							</div>
 							<label>"Package" annual salary</label>
-							<input type="text" placeholder="76650" id="annualinc" rel="tooltip" title="What the recruiter will quote you as 'package', inc super ex tax" />
+							<div class="input-with-premium">
+								<input type="text" placeholder="76650" id="annualinc" rel="tooltip" title="What the recruiter will quote you as 'package', inc super ex tax" />
+								<input type="text" id="annualinc_premium" readonly class="premium-input" placeholder="—" title="Package salary equivalent of the premium day rate" />
+							</div>
 							<label>Daily contract rate (inc superannuation, ex GST)</label>
-							<input type="text" placeholder="337.67" id="dailyinc" rel="toolip" title="Daily rate net of the standard days off in 'Assumptions'" />
-							<div id="daily-premium-row" style="display:none">
-								<label>Daily rate with <span id="risk-pct-label">0%</span> risk premium</label>
-								<input type="text" id="dailypremium" readonly placeholder="—" title="Day rate including the risk premium — what you should actually charge" />
+							<div class="input-with-premium">
+								<input type="text" placeholder="337.67" id="dailyinc" rel="toolip" title="Daily rate net of the standard days off in 'Assumptions'" />
+								<input type="text" id="dailypremium" readonly class="premium-input" placeholder="—" title="Day rate including the risk premium — what you should actually charge" />
 							</div>
 						</fieldset>
 					</div>
@@ -283,17 +292,23 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						this.value = format((this.value * 1).toFixed(0));
 					});
 				}
-				// Update premium day rate field (only when risk_premium gate is active)
+				// Update premium column (only when risk_premium gate is active)
 				if (window.__riskPremiumEnabled) {
 					var rawDaily = unformat($('#dailyinc').val());
 					var riskPct = parseFloat($('#riskpremium').val() || 0);
 					if (rawDaily > 0 && riskPct > 0) {
+						$('#annualex_premium').val(format((unformat($('#annualex').val()) * riskMultiplier).toFixed(0)));
+						$('#annualinc_premium').val(format((unformat($('#annualinc').val()) * riskMultiplier).toFixed(0)));
 						$('#dailypremium').val(format((rawDaily * riskMultiplier).toFixed(0)));
 						$('#risk-pct-label').text(riskPct + '%');
-						$('#daily-premium-row').show();
+						$('.premium-input').show();
+						$('.input-with-premium').addClass('showing-premium');
+						$('#premium-col-head').show();
 					} else {
-						$('#dailypremium').val('');
-						$('#daily-premium-row').hide();
+						$('#annualex_premium,#annualinc_premium,#dailypremium').val('');
+						$('.premium-input').hide();
+						$('.input-with-premium').removeClass('showing-premium');
+						$('#premium-col-head').hide();
 					}
 				}
 				savePrefs();


### PR DESCRIPTION
When the `risk_premium` gate is on and the slider is above 0%, all three fields now show their premium equivalent in a column alongside the standard value.

**Layout:**
- Column heading: "With X% risk premium" (right-aligned over the premium column)
- Standard annual salary: `annualex` | `annualex_premium`
- Package salary: `annualinc` | `annualinc_premium`
- Daily rate: `dailyinc` | `dailypremium`

At 0% the premium column is hidden and all inputs span full width as before.