### PR TITLE
Add dark mode toggle

### DIFF
--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -412,3 +412,239 @@ html.design-2026 .risk-premium-hint {
         font-size: 1rem;
     }
 }
+
+/* ---- Theme toggle ---- */
+.theme-toggle {
+    float: right;
+    margin: 8px 0 0 12px;
+    font-weight: 600;
+}
+
+.theme-toggle .theme-toggle-icon {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: #1a202c;
+    box-shadow: inset -4px -3px 0 #fff;
+    vertical-align: -2px;
+}
+
+html.dark-mode .theme-toggle .theme-toggle-icon {
+    background: #fbbf24;
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, .22);
+}
+
+html.design-2026 .theme-toggle {
+    margin-top: 10px;
+    padding: 8px 12px;
+    border-radius: 999px !important;
+    border: 1px solid rgba(255,255,255,.22) !important;
+    background: rgba(255,255,255,.08);
+    background-image: none !important;
+    color: #fff;
+    text-shadow: none;
+    -webkit-box-shadow: none !important;
+    box-shadow: none !important;
+}
+
+html.design-2026 .theme-toggle:hover,
+html.design-2026 .theme-toggle:focus {
+    background: rgba(255,255,255,.16);
+    color: #fff;
+}
+
+/* ---- Dark mode: legacy Bootstrap layout ---- */
+html.dark-mode body {
+    background: #0f172a;
+    color: #e2e8f0;
+}
+
+html.dark-mode a {
+    color: #93c5fd;
+}
+
+html.dark-mode .navbar-inverse .navbar-inner {
+    background: #020617 !important;
+    background-image: none !important;
+    border-color: #1e293b !important;
+}
+
+html.dark-mode .navbar .brand {
+    color: #f8fafc !important;
+    text-shadow: none !important;
+}
+
+html.dark-mode .hero-unit,
+html.dark-mode .modal-content,
+html.dark-mode .modal-body,
+html.dark-mode .modal-header,
+html.dark-mode .modal-footer {
+    background: #1e293b;
+    color: #e2e8f0;
+}
+
+html.dark-mode .hero-unit p,
+html.dark-mode .row p,
+html.dark-mode label {
+    color: #cbd5e1;
+}
+
+html.dark-mode legend {
+    color: #f8fafc;
+    border-bottom-color: #334155;
+}
+
+html.dark-mode input[type="text"],
+html.dark-mode input[type="email"],
+html.dark-mode input[type="range"] {
+    background: #111827;
+    color: #f8fafc;
+    border-color: #475569;
+}
+
+html.dark-mode input::-webkit-input-placeholder {
+    color: #94a3b8;
+}
+
+html.dark-mode input::-moz-placeholder {
+    color: #94a3b8;
+}
+
+html.dark-mode input:-ms-input-placeholder {
+    color: #94a3b8;
+}
+
+html.dark-mode .theme-toggle {
+    background: #1e293b;
+    background-image: none;
+    border-color: #475569;
+    color: #f8fafc;
+    text-shadow: none;
+}
+
+html.dark-mode .theme-toggle:hover,
+html.dark-mode .theme-toggle:focus {
+    background: #334155;
+    color: #fff;
+}
+
+/* ---- Dark mode: Design 2026 layout ---- */
+html.design-2026.dark-mode body {
+    background: #0f172a;
+    color: #e2e8f0;
+}
+
+html.design-2026.dark-mode .navbar-inner {
+    background: #020617 !important;
+}
+
+html.design-2026.dark-mode .site-name {
+    color: #f8fafc;
+}
+
+html.design-2026.dark-mode h1,
+html.design-2026.dark-mode .hero-unit p,
+html.design-2026.dark-mode .row:last-child p,
+html.design-2026.dark-mode label {
+    color: #cbd5e1;
+}
+
+html.design-2026.dark-mode .hero-unit,
+html.design-2026.dark-mode .row > form,
+html.design-2026.dark-mode .row:last-child {
+    background: #111827;
+    border-color: #334155;
+    box-shadow: 0 1px 3px rgba(0,0,0,.35);
+}
+
+html.design-2026.dark-mode .span5 {
+    border-left-color: #334155;
+}
+
+html.design-2026.dark-mode legend {
+    background: #111827;
+    color: #94a3b8;
+}
+
+html.design-2026.dark-mode label b,
+html.design-2026.dark-mode #risk-premium-section label {
+    color: #f8fafc;
+}
+
+html.design-2026.dark-mode input[type="text"] {
+    background: #0f172a;
+    border-color: #475569 !important;
+    color: #f8fafc;
+}
+
+html.design-2026.dark-mode input[type="text"]:focus {
+    background: #020617;
+    border-color: #34d399 !important;
+    -webkit-box-shadow: 0 0 0 3px rgba(52,211,153,.16) !important;
+    box-shadow: 0 0 0 3px rgba(52,211,153,.16) !important;
+}
+
+html.design-2026.dark-mode input#annualex,
+html.design-2026.dark-mode input#annualinc,
+html.design-2026.dark-mode input#dailyinc {
+    background: #052e2b;
+    border-color: #047857 !important;
+}
+
+html.design-2026.dark-mode input.premium-input {
+    background: #064e3b;
+    border-color: #10b981 !important;
+    color: #bbf7d0;
+}
+
+html.design-2026.dark-mode .premium-col-head-label,
+html.design-2026.dark-mode #risk-pct-label,
+html.design-2026.dark-mode #riskpremium-display,
+html.design-2026.dark-mode .hero-unit a {
+    color: #6ee7b7;
+}
+
+html.design-2026.dark-mode .settings-toggle {
+    background: #0f172a;
+    border-color: #475569 !important;
+    color: #cbd5e1;
+}
+
+html.design-2026.dark-mode .settings-toggle:hover {
+    background: #052e2b;
+    border-color: #34d399 !important;
+    color: #bbf7d0;
+}
+
+html.design-2026.dark-mode .settings-chevron,
+html.design-2026.dark-mode .risk-premium-labels {
+    color: #94a3b8;
+}
+
+html.design-2026.dark-mode #risk-premium-section {
+    border-bottom-color: #334155;
+}
+
+html.design-2026.dark-mode .risk-premium-hint {
+    color: #94a3b8;
+}
+
+html.design-2026.dark-mode .theme-toggle {
+    background: rgba(148,163,184,.12);
+    border-color: rgba(226,232,240,.2) !important;
+    color: #f8fafc;
+}
+
+html.design-2026.dark-mode .theme-toggle:hover,
+html.design-2026.dark-mode .theme-toggle:focus {
+    background: rgba(148,163,184,.2);
+}
+
+@media (max-width: 620px) {
+    html.design-2026.dark-mode .span5 {
+        border-left: none;
+        border-top-color: #334155;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -4,13 +4,30 @@
 		<meta charset="utf-8">
 		<title>Contract or Permie?</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="color-scheme" content="light dark">
 		<meta name="description" content="Calculator for Australians to compare contract rates with the equivalent permanent rates.">
 		<meta name="author" content="Simon Rumble">
 
 		<!-- Cover the page until feature gates resolve to prevent design flicker.
 		     A white div rather than visibility:hidden keeps the DOM accessible to
 		     rrweb (session replay), which crashes when the root element is hidden. -->
-		<style>#gate-cover{position:fixed;inset:0;background:#fff;z-index:9999;pointer-events:none}</style>
+		<style>#gate-cover{position:fixed;inset:0;background:#fff;z-index:9999;pointer-events:none}html.dark-mode #gate-cover{background:#0f172a}</style>
+		<script>
+		(function() {
+			var storageKey = 'cp.pref.color_scheme';
+			var storedTheme = null;
+			try {
+				storedTheme = localStorage.getItem(storageKey);
+			} catch (e) {}
+
+			var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+			var theme = storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : (prefersDark ? 'dark' : 'light');
+
+			document.documentElement.classList.toggle('dark-mode', theme === 'dark');
+			document.documentElement.setAttribute('data-color-scheme', theme);
+			window.__CP_THEME_KEY = storageKey;
+		})();
+		</script>
 
 		<!-- Le styles -->
 		<link href="css/bootstrap.min.css" rel="stylesheet">
@@ -107,6 +124,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						<span class="icon-bar"></span>
 						<span class="icon-bar"></span>
 					</a>
+					<button type="button" id="theme-toggle" class="btn theme-toggle pull-right" aria-label="Switch to dark mode" aria-pressed="false">
+						<span class="theme-toggle-icon" aria-hidden="true"></span>
+						<span id="theme-toggle-label">Dark mode</span>
+					</button>
 					<a class="brand" href="#">Contract or Permie?</a>
 				</div>
 			</div>
@@ -232,6 +253,68 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			}
 		}
 
+		function getStoredTheme() {
+			try {
+				var storedTheme = localStorage.getItem(window.__CP_THEME_KEY || 'cp.pref.color_scheme');
+				return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+			} catch (e) {
+				return null;
+			}
+		}
+
+		function setStoredTheme(theme) {
+			try {
+				localStorage.setItem(window.__CP_THEME_KEY || 'cp.pref.color_scheme', theme);
+			} catch (e) {}
+		}
+
+		function getSystemTheme() {
+			return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+		}
+
+		function applyTheme(theme) {
+			var isDark = theme === 'dark';
+			var toggle = document.getElementById('theme-toggle');
+			var label = document.getElementById('theme-toggle-label');
+
+			document.documentElement.classList.toggle('dark-mode', isDark);
+			document.documentElement.setAttribute('data-color-scheme', theme);
+
+			if (toggle) {
+				toggle.setAttribute('aria-pressed', String(isDark));
+				toggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+			}
+			if (label) {
+				label.textContent = isDark ? 'Light mode' : 'Dark mode';
+			}
+		}
+
+		function initThemeToggle() {
+			var toggle = document.getElementById('theme-toggle');
+			if (!toggle) return;
+
+			applyTheme(getStoredTheme() || getSystemTheme());
+			toggle.addEventListener('click', function() {
+				var nextTheme = document.documentElement.classList.contains('dark-mode') ? 'light' : 'dark';
+				setStoredTheme(nextTheme);
+				applyTheme(nextTheme);
+			});
+
+			if (window.matchMedia) {
+				var themeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+				var syncSystemTheme = function(event) {
+					if (getStoredTheme() === null) {
+						applyTheme(event.matches ? 'dark' : 'light');
+					}
+				};
+				if (themeQuery.addEventListener) {
+					themeQuery.addEventListener('change', syncSystemTheme);
+				} else if (themeQuery.addListener) {
+					themeQuery.addListener(syncSystemTheme);
+				}
+			}
+		}
+
 		$('input').change(function() {
 				// Record the actually-entered field value before we format it down lower
 				fieldValue = this.value;
@@ -354,6 +437,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 			});
 		loadPrefs();
+		initThemeToggle();
 
 		// Add the tooltips to the input fields
 		$('input').tooltip({'placement' : 'right'})

--- a/index.html
+++ b/index.html
@@ -15,17 +15,28 @@
 		<script>
 		(function() {
 			var storageKey = 'cp.pref.color_scheme';
-			var storedTheme = null;
-			try {
-				storedTheme = localStorage.getItem(storageKey);
-			} catch (e) {}
 
-			var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-			var theme = storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : (prefersDark ? 'dark' : 'light');
+			function getStoredTheme() {
+				try {
+					var storedTheme = localStorage.getItem(storageKey);
+					return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+				} catch (e) {
+					return null;
+				}
+			}
 
-			document.documentElement.classList.toggle('dark-mode', theme === 'dark');
-			document.documentElement.setAttribute('data-color-scheme', theme);
+			function getSystemTheme() {
+				return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+			}
+
 			window.__CP_THEME_KEY = storageKey;
+			window.__CP_RESOLVE_THEME = function() {
+				return getStoredTheme() || getSystemTheme();
+			};
+			window.__CP_APPLY_THEME_CLASS = function(theme) {
+				document.documentElement.classList.toggle('dark-mode', theme === 'dark');
+				document.documentElement.setAttribute('data-color-scheme', theme);
+			};
 		})();
 		</script>
 
@@ -99,6 +110,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	// initializeAsync fetches fresh values; remove cover once gates are known.
 	window.__statsigReady = statsigClient.initializeAsync().then(function() {
 		clearTimeout(safetyTimer);
+		if (statsigClient.checkGate('dark_mode') && window.__CP_APPLY_THEME_CLASS && window.__CP_RESOLVE_THEME) {
+			window.__darkModeEnabled = true;
+			window.__CP_APPLY_THEME_CLASS(window.__CP_RESOLVE_THEME());
+		}
 		revealPage();
 	}, function() {
 		clearTimeout(safetyTimer);
@@ -124,7 +139,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						<span class="icon-bar"></span>
 						<span class="icon-bar"></span>
 					</a>
-					<button type="button" id="theme-toggle" class="btn theme-toggle pull-right" aria-label="Switch to dark mode" aria-pressed="false">
+					<button type="button" id="theme-toggle" class="btn theme-toggle pull-right" style="display:none" aria-label="Switch to dark mode" aria-pressed="false">
 						<span class="theme-toggle-icon" aria-hidden="true"></span>
 						<span id="theme-toggle-label">Dark mode</span>
 					</button>
@@ -277,8 +292,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			var toggle = document.getElementById('theme-toggle');
 			var label = document.getElementById('theme-toggle-label');
 
-			document.documentElement.classList.toggle('dark-mode', isDark);
-			document.documentElement.setAttribute('data-color-scheme', theme);
+			if (window.__CP_APPLY_THEME_CLASS) {
+				window.__CP_APPLY_THEME_CLASS(theme);
+			}
 
 			if (toggle) {
 				toggle.setAttribute('aria-pressed', String(isDark));
@@ -291,8 +307,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 		function initThemeToggle() {
 			var toggle = document.getElementById('theme-toggle');
-			if (!toggle) return;
+			if (!toggle || toggle.getAttribute('data-theme-toggle-ready') === 'true') return;
 
+			toggle.style.display = 'inline-block';
+			toggle.setAttribute('data-theme-toggle-ready', 'true');
 			applyTheme(getStoredTheme() || getSystemTheme());
 			toggle.addEventListener('click', function() {
 				var nextTheme = document.documentElement.classList.contains('dark-mode') ? 'light' : 'dark';
@@ -437,7 +455,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 			});
 		loadPrefs();
-		initThemeToggle();
 
 		// Add the tooltips to the input fields
 		$('input').tooltip({'placement' : 'right'})
@@ -454,6 +471,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 					if (window.statsigClient.checkGate('update_styles_2026')) {
 						document.documentElement.classList.add('design-2026');
 					}
+				}
+				if (window.statsigClient && window.statsigClient.checkGate('dark_mode')) {
+					window.__darkModeEnabled = true;
+					initThemeToggle();
 				}
 				if (window.statsigClient && window.statsigClient.checkGate('risk_premium')) {
 					window.__riskPremiumEnabled = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an early page-load theme resolver that reads localStorage before falling back to the OS/browser color-scheme preference
- gate dark-mode activation and the top-right toggle behind Statsig `dark_mode`
- persist user-selected light/dark preferences to localStorage when the gated toggle is used
- add dark-mode styling for both the legacy Bootstrap view and the gated 2026 design

## Verification
- `python3` static checks for expected markup, localStorage key, OS preference fallback, `dark_mode` gate usage, and CSS hooks
- `git diff --check`
- `node` stubbed browser test for gated first-render theme resolution: no theme class applies before the gate path; stored light/dark preferences override OS preference once gated; missing preference follows OS light/dark preference
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a1bb3d3-7e5d-4c61-9060-3df23f7523ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a1bb3d3-7e5d-4c61-9060-3df23f7523ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

