### PR TITLE
Fix premium column overflow on mobile

### DIFF
--- a/css/design-2026.css
+++ b/css/design-2026.css
@@ -140,6 +140,10 @@ html.design-2026 .span7 {
     flex: 1.4;
 }
 
+html.design-2026 #main-fields {
+    min-width: 0;
+}
+
 /* Column divider */
 html.design-2026 .span5 {
     border-left: 1px solid #edf2f7;
@@ -240,39 +244,47 @@ html.design-2026 input.premium-input {
 
 /* Side-by-side layout when premium column is visible */
 html.design-2026 .input-with-premium.showing-premium {
-    display: -webkit-flex;
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 12px;
+    min-width: 0;
 }
 
 html.design-2026 .input-with-premium.showing-premium input {
-    -webkit-flex: 1;
-    flex: 1;
-    width: auto !important;
+    width: 100% !important;
+    min-width: 0;
+}
+
+html.design-2026 .input-with-premium.showing-premium .premium-input {
+    display: block;
 }
 
 /* Column heading */
 html.design-2026 #premium-col-head {
-    display: -webkit-flex;
-    display: flex;
+    display: none;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 12px;
     margin-bottom: 6px;
+    min-width: 0;
+}
+
+html.design-2026 #premium-col-head.is-visible {
+    display: grid;
 }
 
 html.design-2026 .premium-col-head-spacer {
-    -webkit-flex: 1;
-    flex: 1;
+    min-width: 0;
 }
 
 html.design-2026 .premium-col-head-label {
-    -webkit-flex: 1;
-    flex: 1;
+    min-width: 0;
     font-size: 0.6875rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: #276749;
     text-align: center;
+    line-height: 1.35;
 }
 
 html.design-2026 #risk-pct-label {
@@ -387,6 +399,7 @@ html.design-2026 .risk-premium-hint {
         flex-direction: column;
         gap: 20px;
         padding: 20px;
+        overflow: hidden;
     }
 
     html.design-2026 .span5 {
@@ -410,6 +423,23 @@ html.design-2026 .risk-premium-hint {
 
     html.design-2026 h1 {
         font-size: 1rem;
+    }
+
+    /* Keep dual salary columns inside the card on narrow viewports */
+    html.design-2026 .input-with-premium.showing-premium,
+    html.design-2026 #premium-col-head.is-visible {
+        gap: 8px;
+    }
+
+    html.design-2026 .input-with-premium.showing-premium input {
+        padding-left: 8px;
+        padding-right: 8px;
+        font-size: 0.8125rem;
+    }
+
+    html.design-2026 .premium-col-head-label {
+        font-size: 0.625rem;
+        letter-spacing: 0.04em;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 					<div class="span7">
 						<fieldset id="main-fields">
 							<legend>Type in the number you have</legend>
-							<div id="premium-col-head" style="display:none">
+							<div id="premium-col-head">
 								<div class="premium-col-head-spacer"></div>
 								<div class="premium-col-head-label">With <span id="risk-pct-label">0%</span> risk premium</div>
 							</div>
@@ -402,14 +402,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						$('#annualinc_premium').val(format((unformat($('#annualinc').val()) * riskMultiplier).toFixed(0)));
 						$('#dailypremium').val(format((rawDaily * riskMultiplier).toFixed(0)));
 						$('#risk-pct-label').text(riskPct + '%');
-						$('.premium-input').show();
 						$('.input-with-premium').addClass('showing-premium');
-						$('#premium-col-head').show();
+						$('#premium-col-head').addClass('is-visible');
 					} else {
 						$('#annualex_premium,#annualinc_premium,#dailypremium').val('');
-						$('.premium-input').hide();
 						$('.input-with-premium').removeClass('showing-premium');
-						$('#premium-col-head').hide();
+						$('#premium-col-head').removeClass('is-visible');
 					}
 				}
 				savePrefs();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On narrow viewports (e.g. iPhone SE in portrait), when a risk premium is active the second column of salary fields extended past the calculator card border.

## Solution

- Switched the dual-column premium layout from flexbox to CSS grid with `minmax(0, 1fr)` columns so both fields can shrink within the card
- Added `min-width: 0` on the main fields container and grid children (classic flex/grid overflow fix)
- On viewports ≤620px: slightly smaller font and horizontal padding on paired inputs, tighter column gap, and `overflow: hidden` on the form card
- Replaced jQuery `.show()` / `.hide()` on the premium column with CSS classes so inline `display: block` no longer overrides the grid layout

## Verification

Checked at 320×568px with 15% risk premium. Values up to `$1,000,000` / `$1,150,000` stay fully visible and within the card bounds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6d3dabc-dfe1-448c-a960-2203f3d6c98d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6d3dabc-dfe1-448c-a960-2203f3d6c98d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

