### PR TITLE
Fix tooltips clipping off-screen on narrow viewports

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -153,6 +153,7 @@
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 		<script src="js/bootstrap.js"></script>
+		<script src="js/tooltip-viewport.js"></script>
 		<script type="text/javascript">
 			$('input').change(function() {
 				$('#listsubscribe').fadeIn()
@@ -190,8 +191,8 @@
 				}
 
 			});
-		// Add the tooltips to the input fields
-		$('input').tooltip({'placement' : 'right'})
+		// Add the tooltips to the input fields (viewport-aware on narrow screens)
+		initViewportTooltips('input');
 		</script>
 
 	</body>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
 			body {
 				padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
 			}
+			.tooltip-inner {
+				max-width: min(200px, calc(100vw - 24px));
+			}
 		</style>
 		<link href="css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="css/design-2026.css" rel="stylesheet">
@@ -227,6 +230,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 		<script src="js/bootstrap.js"></script>
+		<script src="js/tooltip-viewport.js"></script>
 		<script type="text/javascript">
 			function format(input) {
 				return new Intl.NumberFormat('en-AU', {style: 'currency', currency: 'AUD', maximumSignificantDigits: 3}).format(input); 
@@ -454,8 +458,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			});
 		loadPrefs();
 
-		// Add the tooltips to the input fields
-		$('input').tooltip({'placement' : 'right'})
+		// Add the tooltips to the input fields (viewport-aware on narrow screens)
+		initViewportTooltips('input');
 
 		// Live display update for risk premium slider (fires while dragging)
 		$('#riskpremium').on('input', function() {

--- a/js/tooltip-viewport.js
+++ b/js/tooltip-viewport.js
@@ -1,0 +1,110 @@
+/**
+ * Keeps Bootstrap 2 tooltips inside the viewport on narrow screens.
+ */
+(function ($) {
+	var VIEWPORT_MARGIN = 12;
+	var DEFAULT_TIP_WIDTH = 200;
+
+	function measureTip($tip) {
+		if (!$tip || !$tip.length) {
+			return { width: DEFAULT_TIP_WIDTH, height: 40 };
+		}
+
+		var wasHidden = !$tip.is(':visible') || $tip.css('display') === 'none';
+		if (wasHidden) {
+			$tip.appendTo(document.body).css({
+				position: 'absolute',
+				visibility: 'hidden',
+				display: 'block',
+				top: -9999,
+				left: -9999
+			});
+		}
+
+		var size = { width: $tip.outerWidth(), height: $tip.outerHeight() };
+
+		if (wasHidden) {
+			$tip.detach().css({
+				position: '',
+				visibility: '',
+				display: '',
+				top: '',
+				left: ''
+			});
+		}
+
+		return size;
+	}
+
+	window.resolveTooltipPlacement = function (tip, element) {
+		var rect = element.getBoundingClientRect();
+		var tipSize = measureTip($(tip));
+		var tipW = tipSize.width;
+		var tipH = tipSize.height;
+		var vw = window.innerWidth;
+		var vh = window.innerHeight;
+
+		if (rect.right + tipW + VIEWPORT_MARGIN <= vw) {
+			return 'right';
+		}
+		if (rect.left - tipW - VIEWPORT_MARGIN >= 0) {
+			return 'left';
+		}
+		if (rect.bottom + tipH + VIEWPORT_MARGIN <= vh) {
+			return 'bottom';
+		}
+		if (rect.top - tipH - VIEWPORT_MARGIN >= 0) {
+			return 'top';
+		}
+		return 'bottom';
+	};
+
+	window.clampTooltipInViewport = function ($tip) {
+		if (!$tip || !$tip.length) {
+			return;
+		}
+
+		var margin = VIEWPORT_MARGIN;
+		var pos = $tip.offset();
+		var tipW = $tip.outerWidth();
+		var tipH = $tip.outerHeight();
+		var scrollLeft = $(window).scrollLeft();
+		var scrollTop = $(window).scrollTop();
+		var minLeft = scrollLeft + margin;
+		var maxLeft = scrollLeft + $(window).width() - tipW - margin;
+		var minTop = scrollTop + margin;
+		var maxTop = scrollTop + $(window).height() - tipH - margin;
+		var left = Math.min(Math.max(pos.left, minLeft), maxLeft);
+		var top = Math.min(Math.max(pos.top, minTop), maxTop);
+
+		if (left !== pos.left || top !== pos.top) {
+			$tip.offset({ top: top, left: left });
+		}
+	};
+
+	function patchTooltipShow() {
+		var Tooltip = $.fn.tooltip.Constructor;
+		if (Tooltip.prototype.show.__viewportPatched) {
+			return;
+		}
+
+		var originalShow = Tooltip.prototype.show;
+		Tooltip.prototype.show = function () {
+			originalShow.apply(this, arguments);
+			if (this.$tip && this.$tip.hasClass('in')) {
+				clampTooltipInViewport(this.$tip);
+			}
+		};
+		Tooltip.prototype.show.__viewportPatched = true;
+	}
+
+	window.initViewportTooltips = function (selector) {
+		patchTooltipShow();
+		$(selector).tooltip({ placement: resolveTooltipPlacement });
+		$(window).on('resize orientationchange', function () {
+			$('.tooltip.in').each(function () {
+				clampTooltipInViewport($(this));
+			});
+		});
+	};
+})(jQuery);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On narrow displays (e.g. iPhone SE), input tooltips were always placed to the **right** of the field. With the dual salary/premium columns, the right-hand fields have little room on that side, so tooltips were clipped by the viewport edge.

## Solution

- Added `js/tooltip-viewport.js` to choose placement (`right`, `left`, `top`, or `bottom`) based on available viewport space around the focused input
- Clamp tooltip position after each show so it stays within the viewport (handles long text and resize/orientation changes)
- Cap `.tooltip-inner` max-width to `min(200px, calc(100vw - 24px))` so text wraps on very narrow screens

## Testing

On a ~320px-wide viewport, focus inputs in the premium (right) column — tooltips should appear above or below the field and remain fully readable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e2d0a22-a708-476b-9ec1-1a32ff3d87b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e2d0a22-a708-476b-9ec1-1a32ff3d87b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

