### PR TITLE
Wait for Statsig Ready before checking feature gates

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,15 +92,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 	var statsigClient = new _s.StatsigClient(window.__STATSIG_KEY, {
 		customIDs: { stableID: stableID }
 	});
-
-	_s.runStatsigSessionReplay(statsigClient);
-	_s.runStatsigAutoCapture(statsigClient);
 	window.statsigClient = statsigClient;
 
 	var gatesChecked = false;
+	var pluginsStarted = false;
+	var readySettled = false;
+	var resolveStatsigReady;
+
+	function isStatsigReady() {
+		return statsigClient.loadingStatus === 'Ready';
+	}
+
+	function startStatsigPlugins() {
+		if (pluginsStarted) return;
+		pluginsStarted = true;
+		_s.runStatsigSessionReplay(statsigClient);
+		_s.runStatsigAutoCapture(statsigClient);
+	}
 
 	function applyStatsigGates() {
-		if (gatesChecked) return;
+		if (gatesChecked || !isStatsigReady()) return;
 		gatesChecked = true;
 
 		var gates = {
@@ -135,24 +146,49 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		}
 	}
 
+	function settleStatsigReady() {
+		if (readySettled) return;
+		readySettled = true;
+		resolveStatsigReady();
+	}
+
 	function finishWithGates() {
+		if (!isStatsigReady()) return;
 		clearTimeout(safetyTimer);
+		startStatsigPlugins();
 		whenGateCoverReady(function() {
 			applyStatsigGates();
 			revealPage();
+			settleStatsigReady();
 		});
 	}
 
 	function finishWithoutGates() {
 		clearTimeout(safetyTimer);
 		window.__CP_GATES = {};
-		whenGateCoverReady(revealPage);
+		whenGateCoverReady(function() {
+			revealPage();
+			settleStatsigReady();
+		});
 	}
+
+	window.__statsigReady = new Promise(function(resolve) {
+		resolveStatsigReady = resolve;
+	});
+
+	// Bind before initializeAsync so we only check gates once values are Ready.
+	statsigClient.on('values_updated', function(evt) {
+		if (evt && evt.status === 'Ready') {
+			finishWithGates();
+		}
+	});
 
 	// Fallback only: reveal default UI without calling checkGate (avoids stale-cache evaluations).
 	var safetyTimer = setTimeout(finishWithoutGates, 5000);
 
-	window.__statsigReady = statsigClient.initializeAsync().then(finishWithGates, finishWithoutGates);
+	statsigClient.initializeAsync().then(function() {
+		if (isStatsigReady()) finishWithGates();
+	}, finishWithoutGates);
 })();
 </script>
 <!-- End Statsig SDK -->
@@ -497,7 +533,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			$('#riskpremium-display').text(this.value + '%');
 		});
 
-		// DOM updates for gates (evaluated once in head after initializeAsync).
+		// DOM updates for gates (evaluated once in head after values_updated Ready).
 		window.__CP_APPLY_DOM_GATES = function() {
 			var gates = window.__CP_GATES;
 			if (!gates) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Statsig Group Assignment Health warnings for `dark_mode` (and other gates) showing `Loading:Unrecognized` because gates were checked before the SDK finished initializing.

## Changes

- Wait for `values_updated` with `status === 'Ready'` before calling `checkGate`
- Guard gate evaluation with `loadingStatus === 'Ready'`
- Defer `runStatsigSessionReplay` and `runStatsigAutoCapture` until after initialization completes
- Keep the existing 5s safety fallback that reveals the page without calling `checkGate`

## Test plan

- [ ] Load the site and confirm no design flicker (gate cover still works)
- [ ] Verify dark mode toggle appears when the `dark_mode` gate is enabled
- [ ] Check Statsig Group Assignment Health for `dark_mode` — new checks should show `Recognized` instead of `Loading:Unrecognized`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c62b2b5-2e68-4d88-b644-7126b0ee4e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c62b2b5-2e68-4d88-b644-7126b0ee4e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

