### PR TITLE
Fix Settings toggle doing nothing when clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,6 +376,24 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			}
 		}
 
+		function initSettingsToggle() {
+			var toggle = document.getElementById('settings-toggle');
+			if (!toggle || toggle.getAttribute('data-settings-toggle-ready') === 'true') return;
+
+			toggle.setAttribute('data-settings-toggle-ready', 'true');
+			var wrap = document.getElementById('settings-fieldset-wrap');
+			var riskSection = document.getElementById('risk-premium-section');
+			toggle.style.display = 'block';
+			riskSection.style.display = 'block';
+			wrap.style.display = 'none';
+			toggle.addEventListener('click', function() {
+				var open = wrap.style.display !== 'none';
+				wrap.style.display = open ? 'none' : 'block';
+				this.setAttribute('aria-expanded', String(!open));
+				this.querySelector('.settings-chevron').textContent = open ? '\u25bc' : '\u25b2';
+			});
+		}
+
 		function initThemeToggle() {
 			var toggle = document.getElementById('theme-toggle');
 			if (!toggle || toggle.getAttribute('data-theme-toggle-ready') === 'true') return;
@@ -543,18 +561,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			}
 			if (gates.risk_premium) {
 				window.__riskPremiumEnabled = true;
-				var toggle = document.getElementById('settings-toggle');
-				var wrap = document.getElementById('settings-fieldset-wrap');
-				var riskSection = document.getElementById('risk-premium-section');
-				toggle.style.display = 'block';
-				riskSection.style.display = 'block';
-				wrap.style.display = 'none';
-				toggle.addEventListener('click', function() {
-					var open = wrap.style.display !== 'none';
-					wrap.style.display = open ? 'none' : 'block';
-					this.setAttribute('aria-expanded', String(!open));
-					this.querySelector('.settings-chevron').textContent = open ? '\u25bc' : '\u25b2';
-				});
+				initSettingsToggle();
 			}
 		};
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking the **Settings** button appeared to do nothing — the assumptions panel never opened.

## Root cause

`__CP_APPLY_DOM_GATES` can run twice during page load: once from the head Statsig init (`applyStatsigGates`) and once from the footer fallback (`__statsigReady.then(...)`). Each run attached a separate click handler to the Settings button.

Because both handlers toggled the same panel, a single click opened it and then immediately closed it again, leaving the UI unchanged.

## Fix

Extract `initSettingsToggle()` with the same idempotency guard pattern already used by `initThemeToggle()` (`data-settings-toggle-ready`), so the click listener is only registered once.

## Verification

- Reproduced in Playwright: two listeners caused `wrap.style.display` to remain `none` after click
- After fix: one listener, click sets `wrap.style.display` to `block` as expected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d200cfd-5b0d-4349-a897-6d38caa8de5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d200cfd-5b0d-4349-a897-6d38caa8de5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

